### PR TITLE
Fix Kroger cart adds dropping selected ingredients

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -265,7 +265,6 @@ def kroger_search_upcs():
 
     upcs = []
     failed_items = []
-    seen = set()
 
     for raw in items:
         term, label = parse_search_upc_item(raw)
@@ -301,9 +300,9 @@ def kroger_search_upcs():
             continue
         if retried_with:
             print(f"[search-upcs] alternate query matched: '{term}' -> '{retried_with}'")
-        if upc not in seen:
-            seen.add(upc)
-            upcs.append(upc)
+        # Keep one UPC per input ingredient so downstream cart quantities
+        # can reflect how many ingredients mapped to the same product.
+        upcs.append(upc)
 
     return jsonify({"upcs": upcs, "failedItems": failed_items})
 

--- a/frontend/src/App.test.js
+++ b/frontend/src/App.test.js
@@ -1,8 +1,8 @@
 import { render, screen } from '@testing-library/react';
 import App from './App';
 
-test('renders learn react link', () => {
+test('renders Grubify prompt', () => {
   render(<App />);
-  const linkElement = screen.getByText(/learn react/i);
-  expect(linkElement).toBeInTheDocument();
+  const prompt = screen.getByText(/what would you like to cook today/i);
+  expect(prompt).toBeInTheDocument();
 });

--- a/frontend/src/NutrifyAI.js
+++ b/frontend/src/NutrifyAI.js
@@ -20,7 +20,12 @@ import {
 } from 'lucide-react';
 import './NutrifyAI.css';
 
-Modal.setAppElement('#root');
+if (typeof document !== "undefined") {
+  const rootEl = document.getElementById("root");
+  if (rootEl) {
+    Modal.setAppElement(rootEl);
+  }
+}
 
 /** Enable with ?grubify_debug=1 or localStorage grubify_debug=1 */
 function grubifyDebug() {

--- a/functions/index.js
+++ b/functions/index.js
@@ -265,26 +265,30 @@ exports.generateRecipe = onRequest({ secrets: [openaiKey] }, async (req, res) =>
           return res.status(400).json({ error: "No UPCs provided (expected body.upcs)" });
         }
 
-        const seenUpc = new Set();
+        const upcCounts = new Map();
         const upcsOrdered = [];
         for (const u of rawUpcs) {
           const s = String(u ?? "").trim();
           if (!s) continue;
-          if (!seenUpc.has(s)) {
-            seenUpc.add(s);
+          if (!upcCounts.has(s)) {
+            upcCounts.set(s, 1);
             upcsOrdered.push(s);
+          } else {
+            upcCounts.set(s, upcCounts.get(s) + 1);
           }
         }
         if (upcsOrdered.length === 0) {
           return res.status(400).json({ error: "No valid UPC strings in body.upcs" });
         }
+        const requestedUnits = Array.from(upcCounts.values()).reduce((a, b) => a + b, 0);
 
         const addRes = await axios.put(
           "https://api.kroger.com/v1/cart/add",
           {
             items: upcsOrdered.map((upc) => ({
               upc,
-              quantity: 1,
+              // Preserve duplicate UPCs as quantity so no selected ingredients are dropped.
+              quantity: upcCounts.get(upc) || 1,
               modality: "PICKUP",
             })),
           },
@@ -297,11 +301,13 @@ exports.generateRecipe = onRequest({ secrets: [openaiKey] }, async (req, res) =>
         if (addRes.status === 200 || addRes.status === 204) {
           console.log("[addToKrogerCart] cart/add OK", {
             krogerStatus: addRes.status,
-            addedCount: upcsOrdered.length,
+            uniqueUpcCount: upcsOrdered.length,
+            addedCount: requestedUnits,
           });
           return res.status(200).json({
             success: true,
-            addedCount: upcsOrdered.length,
+            addedCount: requestedUnits,
+            uniqueUpcCount: upcsOrdered.length,
             failedItems: [],
           });
         }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- preserve one UPC entry per input ingredient in `POST /kroger/search-upcs` so ingredient-level intent is not lost
- update `addToKrogerCart` Cloud Function to aggregate duplicate UPCs into Kroger cart `quantity` values instead of dropping duplicates
- harden `react-modal` app element setup to avoid test-environment failures
- update the frontend smoke test to assert the current Grubify UI prompt

## Additional hardening now on `main`
- cache duplicate Kroger search terms within each `/kroger/search-upcs` request to avoid repeated identical Kroger.com lookups
- lower/guard Kroger web-search timeout via `KROGER_WEB_SEARCH_TIMEOUT_SECONDS` (default 18s) to reduce route-level 502 risk

## Validation
- `python3 -m pytest backend/database_test.py backend/test_store_handler.py -q` (pass)
- `npm run build` in `frontend/` (pass)
- `CI=true npm test -- --watch=false` in `frontend/` (pass)
- production endpoint probes after deploy:
  - `POST /kroger/search-upcs` fast-path returns `200` JSON
  - duplicate-term probes now complete around one upstream timeout window (~18s) and return `200` JSON `failedItems` instead of repeated `502` responses
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d090ee6b-932b-480b-b626-bd30b4e36557"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d090ee6b-932b-480b-b626-bd30b4e36557"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

